### PR TITLE
C2-4631: Improve performance by reusing internal proxy endpoint event listener and debouncing event listener removal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comlink",
-  "version": "4.3.0",
+  "version": "4.3.0-symphony.1",
   "description": "Comlink makes WebWorkers enjoyable",
   "main": "dist/umd/comlink.js",
   "module": "dist/esm/comlink.mjs",
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rollup -c",
-    "test:unit": "karma start",
+    "test:unit": "CHROME_ONLY=1 karma start",
     "test:types": "tsc -p ./tests/tsconfig.json",
     "test:types:watch": "npm run test:types -- --watch",
     "test": "npm run fmt_test && npm run build && npm run test:types && npm run test:unit",

--- a/src/comlink.ts
+++ b/src/comlink.ts
@@ -16,6 +16,9 @@ import {
   EventSource,
   Message,
   MessageType,
+  hasEventListener,
+  postMessageResolveMap,
+  timeoutRemoveEventListener,
   PostMessageWithOrigin,
   WireValue,
   WireValueType,
@@ -27,6 +30,14 @@ export const createEndpoint = Symbol("Comlink.endpoint");
 export const releaseProxy = Symbol("Comlink.releaseProxy");
 
 const throwMarker = Symbol("Comlink.thrown");
+
+/**
+ * Time in milliseconds to wait before removing event listener
+ * for the internal requestResponseMessage endpoint created by the proxy
+ *
+ * Default debounce 20 seconds
+ */
+let timeDebounceRemoveEventListener = 20 * 1000;
 
 /**
  * Interface of values that were marked to be proxied with `comlink.proxy()`.
@@ -522,6 +533,96 @@ function fromWireValue(value: WireValue): any {
   }
 }
 
+/**
+ * Method to expose changing the debounce time used to cleanup
+ * event listeners for the internal endpoint used in requestResponseMessage
+ * and created by proxy
+ */
+export function setTimeDebounceRemoveEventListener(milliseconds: number) {
+  timeDebounceRemoveEventListener = milliseconds;
+}
+
+function clearEPTimeout(ep: Endpoint) {
+  if (ep[timeoutRemoveEventListener]) {
+    clearTimeout(ep[timeoutRemoveEventListener]);
+    delete ep[timeoutRemoveEventListener];
+  }
+}
+
+function checkRemoveEventListener(ep: Endpoint, l: any) {
+  // clear any existing ep timeout that may be running
+  clearEPTimeout(ep);
+  const epPostMessageResolveMap = ep[postMessageResolveMap];
+  const size = epPostMessageResolveMap ? epPostMessageResolveMap.size : -1;
+
+  // if there are no more promises to be resolved
+  // and the epPostMessageResolveMap size is zero
+  // update the endpoint to set the eventListener to false
+  // clear out the epPostMessageResolveMap
+  // and remove the event listener to clean it up
+  if (size === 0) {
+    ep[timeoutRemoveEventListener] = setTimeout(() => {
+      delete ep[timeoutRemoveEventListener];
+      delete ep[hasEventListener];
+      delete ep[postMessageResolveMap];
+      ep.removeEventListener("message", l);
+    }, timeDebounceRemoveEventListener);
+  }
+}
+
+function postMessageToEP(
+  ep: Endpoint,
+  id: string,
+  msg: Message,
+  transfers?: Transferable[]
+) {
+  // if the endpoint does not have a listener
+  // add an initial event listener and
+  // set the eventListener to true
+  // this way we only have one event listener added per endpoint
+  if (!ep[hasEventListener]) {
+    ep[hasEventListener] = true;
+
+    // add the post message event listener only once
+    ep.addEventListener("message", function l(ev: MessageEvent) {
+      if (!ev.data || !ev.data.id || !ep[postMessageResolveMap]) {
+        return;
+      }
+      const evId = ev.data.id;
+
+      // look up the resolve function that is stored
+      // in postMessageResolveMap
+      const resolve = ep[postMessageResolveMap]!.get(evId);
+
+      if (resolve) {
+        // when resolve is found,
+        // remove the function from postMessageResolveMap
+        // see if there are other pending events on the same endpoint
+        // and then resolve the promise
+        ep[postMessageResolveMap]!.delete(evId);
+        checkRemoveEventListener(ep, l);
+        resolve(ev.data);
+      }
+    } as any);
+  } else {
+    // if the endpoint has an eventListener
+    // then we should check to clear the endpoint timeout
+    clearEPTimeout(ep);
+  }
+
+  // call the start method each time
+  // a message is posted from requestResponseMessage
+  // as this matches the original logic for comlink
+  if (ep.start) {
+    ep.start();
+  }
+
+  // now call the actual post message
+  ep.postMessage({ id, ...msg }, transfers);
+
+  return ep;
+}
+
 function requestResponseMessage(
   ep: Endpoint,
   msg: Message,
@@ -529,17 +630,17 @@ function requestResponseMessage(
 ): Promise<WireValue> {
   return new Promise((resolve) => {
     const id = generateUUID();
-    ep.addEventListener("message", function l(ev: MessageEvent) {
-      if (!ev.data || !ev.data.id || ev.data.id !== id) {
-        return;
-      }
-      ep.removeEventListener("message", l as any);
-      resolve(ev.data);
-    } as any);
-    if (ep.start) {
-      ep.start();
+    // create postMessageResolveMap if it does not exist
+    // this will store the promise resolve values
+    if (!ep[postMessageResolveMap]) {
+      ep[postMessageResolveMap] = new Map();
     }
-    ep.postMessage({ id, ...msg }, transfers);
+    // now store the promise resolve value for
+    // future reference so we can add a single
+    // event listener per endpoint
+    ep[postMessageResolveMap]!.set(id, resolve);
+
+    postMessageToEP(ep, id, msg, transfers);
   });
 }
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -32,9 +32,18 @@ export interface PostMessageWithOrigin {
   ): void;
 }
 
+export const hasEventListener = Symbol("Comlink.ep.hasEventListener"); // boolean: indicates if the endpoint has an event listener
+export const postMessageResolveMap = Symbol("Comlink.ep.postMessageResolveMap"); // map: contains a list of resolve callbacks for the internal post message
+export const timeoutRemoveEventListener = Symbol(
+  "Comlink.ep.timeoutRemoveEventListener"
+); // timeout: reference to the debounce remove event listener timeout
+
 export interface Endpoint extends EventSource {
-  postMessage(message: any, transfer?: Transferable[]): void;
   start?: () => void;
+  [hasEventListener]?: boolean;
+  [postMessageResolveMap]?: Map<string, any>;
+  [timeoutRemoveEventListener]?: ReturnType<typeof setTimeout>;
+  postMessage(message: any, transfer?: Transferable[]): void;
 }
 
 export const enum WireValueType {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -77,6 +77,7 @@ export const enum MessageType {
   CONSTRUCT,
   ENDPOINT,
   RELEASE,
+  PROXYDATA,
 }
 
 export interface GetMessage {
@@ -117,10 +118,16 @@ export interface ReleaseMessage {
   path: string[];
 }
 
+export interface ProxyDataMessage {
+  id?: MessageID;
+  type: MessageType.PROXYDATA;
+}
+
 export type Message =
   | GetMessage
   | SetMessage
   | ApplyMessage
   | ConstructMessage
   | EndpointMessage
-  | ReleaseMessage;
+  | ReleaseMessage
+  | ProxyDataMessage;

--- a/tests/iframe.comlink.test.js
+++ b/tests/iframe.comlink.test.js
@@ -30,4 +30,70 @@ describe("Comlink across iframes", function () {
     const proxy = Comlink.wrap(Comlink.windowEndpoint(this.ifr.contentWindow));
     expect(await proxy(1, 3)).to.equal(4);
   });
+
+  it("can setTimeDebounceRemoveEventListener 100 ms", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(100);
+    const proxy = Comlink.wrap(Comlink.windowEndpoint(this.ifr.contentWindow));
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    expect(await proxy(1, 3)).to.equal(4);
+
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+  });
+
+  it("can setTimeDebounceRemoveEventListener 1000 ms", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(1000);
+    const proxy = Comlink.wrap(Comlink.windowEndpoint(this.ifr.contentWindow));
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    expect(await proxy(1, 3)).to.equal(4);
+
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+  });
 });

--- a/tests/same_window.comlink.test.js
+++ b/tests/same_window.comlink.test.js
@@ -580,6 +580,88 @@ describe("Comlink in the same realm", function () {
     Comlink.expose({ value: 4 }, this.port2);
     expect(await thing.value).to.equal(4);
   });
+
+  it("getProxyData should return properly formatted proxy data", async function () {
+    const thing = Comlink.wrap(this.port1, { value: {} });
+    Comlink.expose({ value: 7 }, this.port2);
+    expect(await thing.value).to.equal(7);
+    const proxyData = await thing[Comlink.getProxyData]();
+
+    expect(proxyData).to.include({ size: 0, hasEventListener: true });
+    expect(proxyData).to.have.any.keys("timeout");
+
+    expect(typeof proxyData.size).to.equal("number");
+    expect(typeof proxyData.hasEventListener).to.equal("boolean");
+    expect(typeof proxyData.timeout).to.equal("number");
+  });
+
+  it("can setTimeDebounceRemoveEventListener 100 ms", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(100);
+    const thing = Comlink.wrap(this.port1);
+    Comlink.expose({ value: 4 }, this.port2);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await thing[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    expect(await thing.value).to.equal(4);
+
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await thing[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await thing[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+  });
+
+  it("can setTimeDebounceRemoveEventListener 1000 ms", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(1000);
+    const thing = Comlink.wrap(this.port1);
+    Comlink.expose({ value: 4 }, this.port2);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await thing[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    expect(await thing.value).to.equal(4);
+
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await thing[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await thing[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+  });
 });
 
 function guardedIt(f) {

--- a/tests/worker.comlink.test.js
+++ b/tests/worker.comlink.test.js
@@ -33,4 +33,294 @@ describe("Comlink across workers", function () {
     const otherProxy = Comlink.wrap(otherEp);
     expect(await otherProxy(20, 1)).to.equal(21);
   });
+
+  it("can setTimeDebounceRemoveEventListener 100 ms", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(100);
+    const proxy = Comlink.wrap(this.worker);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    expect(await proxy(1, 3)).to.equal(4);
+
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+  });
+
+  it("can setTimeDebounceRemoveEventListener 1000 ms", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(1000);
+    const proxy = Comlink.wrap(this.worker);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    expect(await proxy(1, 3)).to.equal(4);
+
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+  });
+
+  it("removes event listener after no calls from another proxy", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(100);
+    const proxy = Comlink.wrap(this.worker);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    const otherEp = await proxy[Comlink.createEndpoint]();
+    Comlink.wrap(otherEp);
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+  });
+
+  it("adds back event listener after calls from self proxy", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(100);
+    const proxy = Comlink.wrap(this.worker);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    const otherEp = await proxy[Comlink.createEndpoint]();
+    const otherProxy = Comlink.wrap(otherEp);
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+
+    expect(await proxy(1, 3)).to.equal(4);
+
+    const proxyDataNew = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataNew).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataNew).to.have.any.keys("timeout");
+  });
+
+  it("does not add back event listener after calls from self proxy", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(100);
+    const proxy = Comlink.wrap(this.worker);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    const otherEp = await proxy[Comlink.createEndpoint]();
+    Comlink.wrap(otherEp);
+    const proxyDataBefore = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataBefore).to.include({ size: 0, hasEventListener: true });
+    expect(proxyDataBefore).to.have.any.keys("timeout");
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const proxyDataAfter = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataAfter).to.include({ size: 0 });
+    expect(proxyDataAfter).to.not.have.any.keys("hasEventListener", "timeout");
+
+    const proxyDataNew = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataNew).to.include({ size: 0 });
+    expect(proxyDataNew).to.not.have.any.keys("hasEventListener", "timeout");
+  });
+
+  it("can have multiple resolve calls completed", async function () {
+    const proxy = Comlink.wrap(this.worker);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    const firstPromise = proxy(1, 3);
+    const proxyDataOne = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataOne).to.include({ size: 1, hasEventListener: true });
+    expect(proxyDataOne).to.not.have.any.keys("timeout");
+
+    const secondPromise = proxy(2, 3);
+    const proxyDataTwo = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataTwo).to.include({ size: 2, hasEventListener: true });
+    expect(proxyDataTwo).to.not.have.any.keys("timeout");
+
+    const thirdPromise = proxy(3, 3);
+    const proxyDataThree = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataThree).to.include({ size: 3, hasEventListener: true });
+    expect(proxyDataThree).to.not.have.any.keys("timeout");
+
+    expect(await firstPromise).to.equal(4);
+
+    const proxyDataResolveOne = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataResolveOne).to.include({ size: 2, hasEventListener: true });
+    expect(proxyDataResolveOne).to.not.have.any.keys("timeout");
+
+    expect(await secondPromise).to.equal(5);
+
+    const proxyDataResolveTwo = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataResolveTwo).to.include({ size: 1, hasEventListener: true });
+    expect(proxyDataResolveTwo).to.not.have.any.keys("timeout");
+
+    expect(await thirdPromise).to.equal(6);
+
+    const proxyDataResolveThree = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataResolveThree).to.include({
+      size: 0,
+      hasEventListener: true,
+    });
+    expect(proxyDataResolveThree).to.have.any.keys("timeout");
+  });
+
+  it("will reset debounce timeout", async function () {
+    Comlink.setTimeDebounceRemoveEventListener(500);
+    const proxy = Comlink.wrap(this.worker);
+    const proxyDataPre = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataPre).to.include({ size: 0 });
+    expect(proxyDataPre).to.not.have.any.keys("hasEventListener", "timeout");
+
+    const firstPromise = proxy(1, 3);
+    const proxyDataOne = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataOne).to.include({ size: 1, hasEventListener: true });
+    expect(proxyDataOne).to.not.have.any.keys("timeout");
+
+    expect(await firstPromise).to.equal(4);
+
+    const proxyDataResolveOne = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataResolveOne).to.include({
+      size: 0,
+      hasEventListener: true,
+    });
+    expect(proxyDataResolveOne).to.have.any.keys("timeout");
+
+    // now there is a timeout, start another proxy call
+    // wait some time and then start another one to clear this out
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // start another call
+    const secondPromise = proxy(2, 3);
+    const proxyDataTwo = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataTwo).to.include({
+      size: 1,
+      hasEventListener: true,
+    });
+    // the timeout will be cleared out
+    expect(proxyDataTwo).to.not.have.any.keys("timeout");
+
+    // complete 2nd promise
+    expect(await secondPromise).to.equal(5);
+
+    // now wait another 400 ms which will be over the 500 ms total
+    // and there should still be an event listener and a timeout
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    const proxyDataTwoB = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataTwoB).to.include({
+      size: 0,
+      hasEventListener: true,
+    });
+    // the timeout will be open
+    expect(proxyDataTwoB).to.have.any.keys("timeout");
+
+    // should be a new timeout reference id
+    expect(proxyDataResolveOne.timeout).to.not.equal(proxyDataTwoB.timeout);
+
+    // now wait a little longer for the last debounced timeout to run
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const proxyDataDone = JSON.parse(
+      JSON.stringify(await proxy[Comlink.getProxyData]())
+    );
+    expect(proxyDataDone).to.include({
+      size: 0,
+    });
+    // the event listener and timeout will be removed
+    expect(proxyDataDone).to.not.have.any.keys("hasEventListener", "timeout");
+  });
 });


### PR DESCRIPTION
## Description

Improve performance by reusing internal proxy endpoint event listener and debouncing event listener removal

## JIRA ticket

[C2-4631](https://perzoinc.atlassian.net/browse/C2-4631)

## Related PRs

[SFE-Lite](https://github.com/SymphonyOSF/SFE-Lite/pull/3108)