### PR TITLE
C2-4631 TransferHandler.serialize() enhancement

### DIFF
--- a/tests/fixtures/worker2.js
+++ b/tests/fixtures/worker2.js
@@ -1,0 +1,26 @@
+importScripts("/base/dist/umd/comlink.js");
+
+// add new handler to serialize 'special' strings
+Comlink.transferHandlers.set("special-strings", {
+  canHandle(s) {
+    return s === "aaa" || s === "bbb";
+  },
+  serialize(s, ep) {
+    nbrOfSerializations++;
+    lastEp = ep;
+    return [{ value: s }, []];
+  },
+  deserialize(serialized) {
+    return serialized.value;
+  },
+});
+
+const api = {
+  echo: (a) => a,
+  operations: {
+    add: (a, b) => a + b,
+    double: (a) => a + a,
+  },
+};
+
+Comlink.expose(api);

--- a/tests/worker2.comlink.test.js
+++ b/tests/worker2.comlink.test.js
@@ -1,0 +1,86 @@
+import * as Comlink from "/base/dist/esm/comlink.mjs";
+
+describe("Comlink TransferHandler across workers", function () {
+  let worker1;
+  let worker2;
+  let nbrOfSerializations = 0;
+  let lastEp = null;
+
+  beforeEach(function () {
+    nbrOfSerializations = 0;
+    lastEp = null;
+
+    // add new handler to serialize 'special' strings
+    Comlink.transferHandlers.set("special-strings", {
+      canHandle(s) {
+        return s === "aaa" || s === "bbb";
+      },
+      serialize(s, ep) {
+        nbrOfSerializations++;
+        lastEp = ep;
+        return [{ value: "_" + s + "_" }, []];
+      },
+      deserialize(serialized) {
+        return serialized.value;
+      },
+    });
+
+    worker1 = new Worker("/base/tests/fixtures/worker2.js");
+    worker2 = new Worker("/base/tests/fixtures/worker2.js");
+  });
+
+  afterEach(function () {
+    Comlink.transferHandlers.delete("special-strings");
+    worker1.terminate();
+    worker2.terminate();
+  });
+
+  it("will pass the endpoint param to serialize() - sub-object call", async function () {
+    const proxy = Comlink.wrap(worker1);
+    const r = await proxy.operations.add("x", "aaa");
+
+    expect(r).to.equal("x_aaa_");
+    expect(nbrOfSerializations).to.equal(1);
+    expect(lastEp).to.equal(worker1);
+  });
+
+  it("will pass the endpoint param to serialize() - double serialization", async function () {
+    const proxy = Comlink.wrap(worker1);
+    const r = await proxy.operations.add("aaa", "bbb");
+
+    expect(r).to.equal("_aaa__bbb_");
+    expect(nbrOfSerializations).to.equal(2);
+    expect(lastEp).to.equal(worker1);
+  });
+
+  it("will not use TransferHandler if canHandle returns false", async function () {
+    const proxy = Comlink.wrap(worker1);
+    const r = await proxy.operations.add("x", "y");
+
+    expect(r).to.equal("xy");
+    expect(nbrOfSerializations).to.equal(0);
+    expect(lastEp).to.equal(null);
+  });
+
+  it("will pass different end points for different workers", async function () {
+    const proxy1 = Comlink.wrap(worker1);
+    const proxy2 = Comlink.wrap(worker2);
+
+    const r1 = await proxy1.echo("aaa");
+    expect(r1).to.equal("_aaa_");
+    expect(nbrOfSerializations).to.equal(1);
+    expect(lastEp).to.equal(worker1);
+
+    nbrOfSerializations = 0;
+    const r2 = await proxy2.operations.double("aaa");
+    expect(r2).to.equal("_aaa__aaa_");
+    expect(nbrOfSerializations).to.equal(1);
+    expect(lastEp).to.equal(worker2);
+
+    nbrOfSerializations = 0;
+    const r3 = await proxy1.operations.double("aaa");
+    expect(r3).to.equal("_aaa__aaa_");
+    expect(nbrOfSerializations).to.equal(1);
+    expect(lastEp).to.equal(worker1);
+  });
+});


### PR DESCRIPTION
This PR adds a new endpoint argument to the _TransferHandler.serialize()_ function - i.e.

```serialize(value: T, ep: Endpoint): [S, Transferable[]];``` 

instead of 

```serialize(value: T): [S, Transferable[]];```

This will enable supporting lighweight callback serialization mechanism (using one MessageChannel per web-worker) on multiple web-workers. As te current comlink implementation doesn't provide any context information to _TransferHandler.serialize()_ we cannot support multiple web-workers as we have no mean to know which MessageChannel should be used if more than one web-worker is used.
